### PR TITLE
chore: update to v0.261.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a custom fork of [nektos/act](https://github.com/nektos/act/), for the p
 
 It cannot be used as command line tool anymore, but only as a library.
 
-It's a soft fork, which means that it will tracking the latest release of nektos/act.
+It's a soft fork, which means that it will track the latest release of nektos/act.
 
 Branches:
 

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -60,6 +60,7 @@ type Input struct {
 	networkName                        string
 	useNewActionCache                  bool
 	localRepository                    []string
+	maxParallel                        int
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.networkName, "network", "", "host", "Sets a docker network name. Defaults to host.")
 	rootCmd.PersistentFlags().BoolVarP(&input.useNewActionCache, "use-new-action-cache", "", false, "Enable using the new Action Cache for storing Actions locally")
 	rootCmd.PersistentFlags().StringArrayVarP(&input.localRepository, "local-repository", "", []string{}, "Replaces the specified repository and ref with a local folder (e.g. https://github.com/test/test@v0=/home/act/test or test/test@v0=/home/act/test, the latter matches any hosts or protocols)")
+	rootCmd.PersistentFlags().IntVarP(&input.maxParallel, "max-parallel", "", 0, "Limits the number of jobs running in parallel across all workflows (0 = no limit, uses number of CPUs)")
 	rootCmd.SetArgs(args())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -561,6 +562,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			ReplaceGheActionTokenWithGithubCom: input.replaceGheActionTokenWithGithubCom,
 			Matrix:                             matrixes,
 			ContainerNetworkMode:               docker_container.NetworkMode(input.networkName),
+			MaxParallel:                        input.maxParallel,
 		}
 		if input.useNewActionCache || len(input.localRepository) > 0 {
 			if input.actionOfflineMode {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 	gitignore "github.com/sabhiram/go-gitignore"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/nektos/act/pkg/artifactcache"
 	"github.com/nektos/act/pkg/artifacts"

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/timshannon/bolthold v0.0.0-20210913165410-232392fc8a6a
 	go.etcd.io/bbolt v1.3.9
+	go.yaml.in/yaml/v4 v4.0.0-rc.2
 	golang.org/x/term v0.18.0
-	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 )
 
@@ -88,4 +88,5 @@ require (
 	golang.org/x/tools v0.13.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -110,7 +111,18 @@ func NewParallelExecutor(parallel int, executors ...Executor) Executor {
 				for executor := range work {
 					taskCount++
 					log.Debugf("Worker %d executing task %d", workerID, taskCount)
-					errs <- executor(ctx)
+					// Recover from panics in executors to avoid crashing the worker
+					// goroutine which would leave the runner process hung.
+					// https://gitea.com/gitea/act_runner/issues/371
+					errs <- func() (err error) {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Errorf("panic in executor: %v\n%s", r, debug.Stack())
+								err = fmt.Errorf("panic: %v", r)
+							}
+						}()
+						return executor(ctx)
+					}()
 				}
 				log.Debugf("Worker %d finished (%d tasks executed)", workerID, taskCount)
 			}(i, work, errs)

--- a/pkg/common/executor_max_parallel_test.go
+++ b/pkg/common/executor_max_parallel_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Simple fast test that verifies max-parallel: 2 limits concurrency
+func TestMaxParallel2Quick(t *testing.T) {
+	ctx := context.Background()
+
+	var currentRunning int32
+	var maxSimultaneous int32
+
+	executors := make([]Executor, 4)
+	for i := 0; i < 4; i++ {
+		executors[i] = func(ctx context.Context) error {
+			current := atomic.AddInt32(&currentRunning, 1)
+
+			// Update max if needed
+			for {
+				maxValue := atomic.LoadInt32(&maxSimultaneous)
+				if current <= maxValue || atomic.CompareAndSwapInt32(&maxSimultaneous, maxValue, current) {
+					break
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt32(&currentRunning, -1)
+			return nil
+		}
+	}
+
+	err := NewParallelExecutor(2, executors...)(ctx)
+
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, atomic.LoadInt32(&maxSimultaneous), int32(2),
+		"Should not exceed max-parallel: 2")
+}
+
+// Test that verifies max-parallel: 1 enforces sequential execution
+func TestMaxParallel1Sequential(t *testing.T) {
+	ctx := context.Background()
+
+	var currentRunning int32
+	var maxSimultaneous int32
+	var executionOrder []int
+	var orderMutex sync.Mutex
+
+	executors := make([]Executor, 5)
+	for i := 0; i < 5; i++ {
+		taskID := i
+		executors[i] = func(ctx context.Context) error {
+			current := atomic.AddInt32(&currentRunning, 1)
+
+			// Track execution order
+			orderMutex.Lock()
+			executionOrder = append(executionOrder, taskID)
+			orderMutex.Unlock()
+
+			// Update max if needed
+			for {
+				maxValue := atomic.LoadInt32(&maxSimultaneous)
+				if current <= maxValue || atomic.CompareAndSwapInt32(&maxSimultaneous, maxValue, current) {
+					break
+				}
+			}
+
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&currentRunning, -1)
+			return nil
+		}
+	}
+
+	err := NewParallelExecutor(1, executors...)(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxSimultaneous),
+		"max-parallel: 1 should only run 1 task at a time")
+	assert.Len(t, executionOrder, 5, "All 5 tasks should have executed")
+}

--- a/pkg/common/executor_parallel_advanced_test.go
+++ b/pkg/common/executor_parallel_advanced_test.go
@@ -1,0 +1,280 @@
+package common
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMaxParallelJobExecution tests actual job execution with max-parallel
+func TestMaxParallelJobExecution(t *testing.T) {
+	t.Run("MaxParallel=1 Sequential", func(t *testing.T) {
+		var currentRunning int32
+		var maxConcurrent int32
+		var executionOrder []int
+		var mu sync.Mutex
+
+		executors := make([]Executor, 5)
+		for i := 0; i < 5; i++ {
+			taskID := i
+			executors[i] = func(ctx context.Context) error {
+				current := atomic.AddInt32(&currentRunning, 1)
+
+				// Track max concurrent
+				for {
+					max := atomic.LoadInt32(&maxConcurrent)
+					if current <= max || atomic.CompareAndSwapInt32(&maxConcurrent, max, current) {
+						break
+					}
+				}
+
+				mu.Lock()
+				executionOrder = append(executionOrder, taskID)
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+				atomic.AddInt32(&currentRunning, -1)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		err := NewParallelExecutor(1, executors...)(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int32(1), maxConcurrent, "Should never exceed 1 concurrent execution")
+		assert.Len(t, executionOrder, 5, "All tasks should execute")
+	})
+
+	t.Run("MaxParallel=3 Limited", func(t *testing.T) {
+		var currentRunning int32
+		var maxConcurrent int32
+
+		executors := make([]Executor, 10)
+		for i := 0; i < 10; i++ {
+			executors[i] = func(ctx context.Context) error {
+				current := atomic.AddInt32(&currentRunning, 1)
+
+				for {
+					max := atomic.LoadInt32(&maxConcurrent)
+					if current <= max || atomic.CompareAndSwapInt32(&maxConcurrent, max, current) {
+						break
+					}
+				}
+
+				time.Sleep(20 * time.Millisecond)
+				atomic.AddInt32(&currentRunning, -1)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		err := NewParallelExecutor(3, executors...)(ctx)
+		assert.NoError(t, err)
+
+		assert.LessOrEqual(t, int(maxConcurrent), 3, "Should never exceed 3 concurrent executions")
+		assert.GreaterOrEqual(t, int(maxConcurrent), 1, "Should have at least 1 concurrent execution")
+	})
+
+	t.Run("MaxParallel=0 Uses1Worker", func(t *testing.T) {
+		var maxConcurrent int32
+		var currentRunning int32
+
+		executors := make([]Executor, 5)
+		for i := 0; i < 5; i++ {
+			executors[i] = func(ctx context.Context) error {
+				current := atomic.AddInt32(&currentRunning, 1)
+
+				for {
+					max := atomic.LoadInt32(&maxConcurrent)
+					if current <= max || atomic.CompareAndSwapInt32(&maxConcurrent, max, current) {
+						break
+					}
+				}
+
+				time.Sleep(10 * time.Millisecond)
+				atomic.AddInt32(&currentRunning, -1)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		// When maxParallel is 0 or negative, it defaults to 1
+		err := NewParallelExecutor(0, executors...)(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int32(1), maxConcurrent, "Should use 1 worker when max-parallel is 0")
+	})
+}
+
+// TestMaxParallelWithErrors tests error handling with max-parallel
+func TestMaxParallelWithErrors(t *testing.T) {
+	t.Run("OneTaskFailsOthersContinue", func(t *testing.T) {
+		var successCount int32
+
+		executors := make([]Executor, 5)
+		for i := 0; i < 5; i++ {
+			taskID := i
+			executors[i] = func(ctx context.Context) error {
+				if taskID == 2 {
+					return assert.AnError
+				}
+				atomic.AddInt32(&successCount, 1)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		err := NewParallelExecutor(2, executors...)(ctx)
+
+		// Should return the error from task 2
+		assert.Error(t, err)
+
+		// Other tasks should still execute
+		assert.Equal(t, int32(4), successCount, "4 tasks should succeed")
+	})
+
+	t.Run("ContextCancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var startedCount int32
+		executors := make([]Executor, 10)
+		for i := 0; i < 10; i++ {
+			executors[i] = func(ctx context.Context) error {
+				atomic.AddInt32(&startedCount, 1)
+				time.Sleep(100 * time.Millisecond)
+				return nil
+			}
+		}
+
+		// Cancel after a short delay
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			cancel()
+		}()
+
+		err := NewParallelExecutor(3, executors...)(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+
+		// Not all tasks should start due to cancellation (but timing may vary)
+		// Just verify cancellation occurred
+		t.Logf("Started %d tasks before cancellation", startedCount)
+	})
+}
+
+// TestMaxParallelPerformance tests performance characteristics
+func TestMaxParallelPerformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping performance test in short mode")
+	}
+
+	t.Run("ParallelFasterThanSequential", func(t *testing.T) {
+		executors := make([]Executor, 10)
+		for i := 0; i < 10; i++ {
+			executors[i] = func(ctx context.Context) error {
+				time.Sleep(50 * time.Millisecond)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+
+		// Sequential (max-parallel=1)
+		start := time.Now()
+		err := NewParallelExecutor(1, executors...)(ctx)
+		sequentialDuration := time.Since(start)
+		assert.NoError(t, err)
+
+		// Parallel (max-parallel=5)
+		start = time.Now()
+		err = NewParallelExecutor(5, executors...)(ctx)
+		parallelDuration := time.Since(start)
+		assert.NoError(t, err)
+
+		// Parallel should be significantly faster
+		assert.Less(t, parallelDuration, sequentialDuration/2,
+			"Parallel execution should be at least 2x faster")
+	})
+
+	t.Run("OptimalWorkerCount", func(t *testing.T) {
+		executors := make([]Executor, 20)
+		for i := 0; i < 20; i++ {
+			executors[i] = func(ctx context.Context) error {
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+
+		// Test with different worker counts
+		workerCounts := []int{1, 2, 5, 10, 20}
+		durations := make(map[int]time.Duration)
+
+		for _, count := range workerCounts {
+			start := time.Now()
+			err := NewParallelExecutor(count, executors...)(ctx)
+			durations[count] = time.Since(start)
+			assert.NoError(t, err)
+		}
+
+		// More workers should generally be faster (up to a point)
+		assert.Less(t, durations[5], durations[1], "5 workers should be faster than 1")
+		assert.Less(t, durations[10], durations[2], "10 workers should be faster than 2")
+	})
+}
+
+// TestMaxParallelResourceSharing tests resource sharing scenarios
+func TestMaxParallelResourceSharing(t *testing.T) {
+	t.Run("SharedResourceWithMutex", func(t *testing.T) {
+		var sharedCounter int
+		var mu sync.Mutex
+
+		executors := make([]Executor, 100)
+		for i := 0; i < 100; i++ {
+			executors[i] = func(ctx context.Context) error {
+				mu.Lock()
+				sharedCounter++
+				mu.Unlock()
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		err := NewParallelExecutor(10, executors...)(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 100, sharedCounter, "All tasks should increment counter")
+	})
+
+	t.Run("ChannelCommunication", func(t *testing.T) {
+		resultChan := make(chan int, 50)
+
+		executors := make([]Executor, 50)
+		for i := 0; i < 50; i++ {
+			taskID := i
+			executors[i] = func(ctx context.Context) error {
+				resultChan <- taskID
+				return nil
+			}
+		}
+
+		ctx := context.Background()
+		err := NewParallelExecutor(5, executors...)(ctx)
+		assert.NoError(t, err)
+
+		close(resultChan)
+
+		results := make(map[int]bool)
+		for result := range resultChan {
+			results[result] = true
+		}
+
+		assert.Len(t, results, 50, "All task IDs should be received")
+	})
+}

--- a/pkg/jobparser/evaluator.go
+++ b/pkg/jobparser/evaluator.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/nektos/act/pkg/exprparser"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ExpressionEvaluator is copied from runner.expressionEvaluator,

--- a/pkg/jobparser/interpeter.go
+++ b/pkg/jobparser/interpeter.go
@@ -3,7 +3,7 @@ package jobparser
 import (
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // NewInterpeter returns an interpeter used in the server,

--- a/pkg/jobparser/jobparser.go
+++ b/pkg/jobparser/jobparser.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"

--- a/pkg/jobparser/jobparser.go
+++ b/pkg/jobparser/jobparser.go
@@ -60,10 +60,11 @@ func Parse(content []byte, options ...ParseOption) ([]*SingleWorkflow, error) {
 			}
 			job.RawRunsOn = encodeRunsOn(runsOn)
 			swf := &SingleWorkflow{
-				Name:     workflow.Name,
-				RawOn:    workflow.RawOn,
-				Env:      workflow.Env,
-				Defaults: workflow.Defaults,
+				Name:           workflow.Name,
+				RawOn:          workflow.RawOn,
+				Env:            workflow.Env,
+				Defaults:       workflow.Defaults,
+				RawPermissions: workflow.RawPermissions,
 			}
 			if err := swf.SetJob(id, job); err != nil {
 				return nil, fmt.Errorf("SetJob: %w", err)

--- a/pkg/jobparser/jobparser_test.go
+++ b/pkg/jobparser/jobparser_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestParse(t *testing.T) {
@@ -49,6 +49,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:    "job_name_with_matrix",
+			options: nil,
+			wantErr: false,
+		},
+		{
+			name:    "prefixed_newline",
 			options: nil,
 			wantErr: false,
 		},

--- a/pkg/jobparser/model.go
+++ b/pkg/jobparser/model.go
@@ -16,6 +16,7 @@ type SingleWorkflow struct {
 	RawJobs        yaml.Node         `yaml:"jobs,omitempty"`
 	Defaults       Defaults          `yaml:"defaults,omitempty"`
 	RawPermissions yaml.Node         `yaml:"permissions,omitempty"`
+	RunName        string            `yaml:"run-name,omitempty"`
 }
 
 func (w *SingleWorkflow) Job() (string, *Job) {

--- a/pkg/jobparser/model.go
+++ b/pkg/jobparser/model.go
@@ -10,11 +10,12 @@ import (
 
 // SingleWorkflow is a workflow with single job and single matrix
 type SingleWorkflow struct {
-	Name     string            `yaml:"name,omitempty"`
-	RawOn    yaml.Node         `yaml:"on,omitempty"`
-	Env      map[string]string `yaml:"env,omitempty"`
-	RawJobs  yaml.Node         `yaml:"jobs,omitempty"`
-	Defaults Defaults          `yaml:"defaults,omitempty"`
+	Name           string            `yaml:"name,omitempty"`
+	RawOn          yaml.Node         `yaml:"on,omitempty"`
+	Env            map[string]string `yaml:"env,omitempty"`
+	RawJobs        yaml.Node         `yaml:"jobs,omitempty"`
+	Defaults       Defaults          `yaml:"defaults,omitempty"`
+	RawPermissions yaml.Node         `yaml:"permissions,omitempty"`
 }
 
 func (w *SingleWorkflow) Job() (string, *Job) {
@@ -84,6 +85,7 @@ type Job struct {
 	With           map[string]interface{}    `yaml:"with,omitempty"`
 	RawSecrets     yaml.Node                 `yaml:"secrets,omitempty"`
 	RawConcurrency *model.RawConcurrency     `yaml:"concurrency,omitempty"`
+	RawPermissions yaml.Node                 `yaml:"permissions,omitempty"`
 }
 
 func (j *Job) Clone() *Job {
@@ -107,6 +109,7 @@ func (j *Job) Clone() *Job {
 		With:           j.With,
 		RawSecrets:     j.RawSecrets,
 		RawConcurrency: j.RawConcurrency,
+		RawPermissions: j.RawPermissions,
 	}
 }
 

--- a/pkg/jobparser/model_test.go
+++ b/pkg/jobparser/model_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestParseRawOn(t *testing.T) {

--- a/pkg/jobparser/testdata/prefixed_newline.in.yaml
+++ b/pkg/jobparser/testdata/prefixed_newline.in.yaml
@@ -1,0 +1,14 @@
+name: Step with leading new line
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "\nExtract tag for variant"
+        id: extract_tag
+        run: |
+
+          echo Test

--- a/pkg/jobparser/testdata/prefixed_newline.out.yaml
+++ b/pkg/jobparser/testdata/prefixed_newline.out.yaml
@@ -1,0 +1,15 @@
+name: Step with leading new line
+"on":
+  push:
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - id: extract_tag
+        name: |2-
+
+          Extract tag for variant
+        run: |2
+
+          echo Test

--- a/pkg/model/action.go
+++ b/pkg/model/action.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ActionRunsUsing is the type of runner for the action

--- a/pkg/model/action.go
+++ b/pkg/model/action.go
@@ -20,7 +20,7 @@ func (a *ActionRunsUsing) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// Force input to lowercase for case insensitive comparison
 	format := ActionRunsUsing(strings.ToLower(using))
 	switch format {
-	case ActionRunsUsingNode20, ActionRunsUsingNode16, ActionRunsUsingNode12, ActionRunsUsingDocker, ActionRunsUsingComposite, ActionRunsUsingGo:
+	case ActionRunsUsingNode24, ActionRunsUsingNode20, ActionRunsUsingNode16, ActionRunsUsingNode12, ActionRunsUsingDocker, ActionRunsUsingComposite, ActionRunsUsingGo:
 		*a = format
 	default:
 		return fmt.Errorf(fmt.Sprintf("The runs.using key in action.yml must be one of: %v, got %s", []string{
@@ -29,6 +29,7 @@ func (a *ActionRunsUsing) UnmarshalYAML(unmarshal func(interface{}) error) error
 			ActionRunsUsingNode12,
 			ActionRunsUsingNode16,
 			ActionRunsUsingNode20,
+			ActionRunsUsingNode24,
 			ActionRunsUsingGo,
 		}, format))
 	}
@@ -42,6 +43,8 @@ const (
 	ActionRunsUsingNode16 = "node16"
 	// ActionRunsUsingNode20 for running with node20
 	ActionRunsUsingNode20 = "node20"
+	// ActionRunsUsingNode24 for running with node24
+	ActionRunsUsingNode24 = "node24"
 	// ActionRunsUsingDocker for running with docker
 	ActionRunsUsingDocker = "docker"
 	// ActionRunsUsingComposite for running composite
@@ -49,6 +52,23 @@ const (
 	// ActionRunsUsingGo for running with go
 	ActionRunsUsingGo = "go"
 )
+
+func (a ActionRunsUsing) IsNode() bool {
+	switch a {
+	case ActionRunsUsingNode12, ActionRunsUsingNode16, ActionRunsUsingNode20, ActionRunsUsingNode24:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a ActionRunsUsing) IsDocker() bool {
+	return a == ActionRunsUsingDocker
+}
+
+func (a ActionRunsUsing) IsComposite() bool {
+	return a == ActionRunsUsingComposite
+}
 
 // ActionRuns are a field in Action
 type ActionRuns struct {

--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -39,6 +39,9 @@ type GithubContext struct {
 	ServerURL        string                 `json:"server_url"`
 	APIURL           string                 `json:"api_url"`
 	GraphQLURL       string                 `json:"graphql_url"`
+
+	// For Gitea
+	RunAttempt string `json:"run_attempt"`
 }
 
 func asString(v interface{}) string {

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/nektos/act/pkg/common"
 )

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -396,6 +396,7 @@ func (j *Job) Matrix() map[string][]interface{} {
 func (j *Job) GetMatrixes() ([]map[string]interface{}, error) {
 	matrixes := make([]map[string]interface{}, 0)
 	if j.Strategy != nil {
+		// Always set these values, even if there's an error later
 		j.Strategy.FailFast = j.Strategy.GetFailFast()
 		j.Strategy.MaxParallel = j.Strategy.GetMaxParallel()
 

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -17,14 +17,14 @@ import (
 
 // Workflow is the structure of the files in .github/workflows
 type Workflow struct {
-	File     string
-	Name     string            `yaml:"name"`
-	RawOn    yaml.Node         `yaml:"on"`
-	Env      map[string]string `yaml:"env"`
-	Jobs     map[string]*Job   `yaml:"jobs"`
-	Defaults Defaults          `yaml:"defaults"`
-
-	RawConcurrency *RawConcurrency `yaml:"concurrency"` // For Gitea
+	File           string
+	Name           string            `yaml:"name"`
+	RawOn          yaml.Node         `yaml:"on"`
+	Env            map[string]string `yaml:"env"`
+	Jobs           map[string]*Job   `yaml:"jobs"`
+	Defaults       Defaults          `yaml:"defaults"`
+	RawConcurrency *RawConcurrency   `yaml:"concurrency"`
+	RawPermissions yaml.Node         `yaml:"permissions"`
 }
 
 // On events for the workflow
@@ -201,6 +201,7 @@ type Job struct {
 	Uses           string                    `yaml:"uses"`
 	With           map[string]interface{}    `yaml:"with"`
 	RawSecrets     yaml.Node                 `yaml:"secrets"`
+	RawPermissions yaml.Node                 `yaml:"permissions"`
 	Result         string
 }
 

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -778,4 +778,22 @@ func decodeNode(node yaml.Node, out interface{}) bool {
 type RawConcurrency struct {
 	Group            string `yaml:"group,omitempty"`
 	CancelInProgress string `yaml:"cancel-in-progress,omitempty"`
+	RawExpression    string `yaml:"-,omitempty"`
+}
+
+type objectConcurrency RawConcurrency
+
+func (r *RawConcurrency) UnmarshalYAML(n *yaml.Node) error {
+	if err := n.Decode(&r.RawExpression); err == nil {
+		return nil
+	}
+	return n.Decode((*objectConcurrency)(r))
+}
+
+func (r *RawConcurrency) MarshalYAML() (interface{}, error) {
+	if r.RawExpression != "" {
+		return r.RawExpression, nil
+	}
+
+	return (*objectConcurrency)(r), nil
 }

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -16,7 +16,7 @@ import (
 	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ExpressionEvaluator is the interface for evaluating expressions

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
 	assert "github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 func createRunContext(t *testing.T) *RunContext {

--- a/pkg/runner/max_parallel_test.go
+++ b/pkg/runner/max_parallel_test.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/nektos/act/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestMaxParallelStrategy(t *testing.T) {
+	tests := []struct {
+		name                string
+		maxParallelString   string
+		expectedMaxParallel int
+	}{
+		{
+			name:                "max-parallel-1",
+			maxParallelString:   "1",
+			expectedMaxParallel: 1,
+		},
+		{
+			name:                "max-parallel-2",
+			maxParallelString:   "2",
+			expectedMaxParallel: 2,
+		},
+		{
+			name:                "max-parallel-default",
+			maxParallelString:   "",
+			expectedMaxParallel: 4,
+		},
+		{
+			name:                "max-parallel-10",
+			maxParallelString:   "10",
+			expectedMaxParallel: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matrix := map[string][]interface{}{
+				"version": {1, 2, 3, 4, 5},
+			}
+
+			var rawMatrix yaml.Node
+			err := rawMatrix.Encode(matrix)
+			assert.NoError(t, err)
+
+			job := &model.Job{
+				Strategy: &model.Strategy{
+					MaxParallelString: tt.maxParallelString,
+					RawMatrix:         rawMatrix,
+				},
+			}
+
+			matrixes, err := job.GetMatrixes()
+			assert.NoError(t, err)
+			assert.NotNil(t, matrixes)
+			assert.Equal(t, 5, len(matrixes))
+			assert.Equal(t, tt.expectedMaxParallel, job.Strategy.MaxParallel)
+		})
+	}
+}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -903,6 +903,7 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 			ghc.Event = preset.Event
 			ghc.RunID = preset.RunID
 			ghc.RunNumber = preset.RunNumber
+			ghc.RunAttempt = preset.RunAttempt
 			ghc.Actor = preset.Actor
 			ghc.Repository = preset.Repository
 			ghc.EventName = preset.EventName
@@ -1065,6 +1066,7 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 		env["GITHUB_SERVER_URL"] = instance
 		env["GITHUB_API_URL"] = instance + "/api/v1" // the version of Gitea is v1
 		env["GITHUB_GRAPHQL_URL"] = ""               // Gitea doesn't support graphql
+		env["GITHUB_RUN_ATTEMPT"] = github.RunAttempt
 	}
 
 	if rc.Config.ArtifactServerPath != "" {

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -15,7 +15,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 func TestRunContext_EvalBool(t *testing.T) {

--- a/pkg/runner/runner_max_parallel_test.go
+++ b/pkg/runner/runner_max_parallel_test.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMaxParallelConfig tests that MaxParallel config is properly set
+func TestMaxParallelConfig(t *testing.T) {
+	t.Run("MaxParallel set to 2", func(t *testing.T) {
+		config := &Config{
+			Workdir:     "testdata",
+			MaxParallel: 2,
+		}
+
+		runner, err := New(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, runner)
+
+		// Verify config is properly stored
+		runnerImpl, ok := runner.(*runnerImpl)
+		assert.True(t, ok)
+		assert.Equal(t, 2, runnerImpl.config.MaxParallel)
+	})
+
+	t.Run("MaxParallel set to 0 (no limit)", func(t *testing.T) {
+		config := &Config{
+			Workdir:     "testdata",
+			MaxParallel: 0,
+		}
+
+		runner, err := New(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, runner)
+
+		runnerImpl, ok := runner.(*runnerImpl)
+		assert.True(t, ok)
+		assert.Equal(t, 0, runnerImpl.config.MaxParallel)
+	})
+
+	t.Run("MaxParallel not set (defaults to 0)", func(t *testing.T) {
+		config := &Config{
+			Workdir: "testdata",
+		}
+
+		runner, err := New(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, runner)
+
+		runnerImpl, ok := runner.(*runnerImpl)
+		assert.True(t, ok)
+		assert.Equal(t, 0, runnerImpl.config.MaxParallel)
+	})
+}
+
+// TestMaxParallelConcurrencyTracking tests that max-parallel actually limits concurrent execution
+func TestMaxParallelConcurrencyTracking(t *testing.T) {
+	// This is a unit test for the parallel executor logic
+	// We test that when MaxParallel is set, it limits the number of workers
+
+	var mu sync.Mutex
+	var maxConcurrent int
+	var currentConcurrent int
+
+	// Create a function that tracks concurrent execution
+	trackingFunc := func() {
+		mu.Lock()
+		currentConcurrent++
+		if currentConcurrent > maxConcurrent {
+			maxConcurrent = currentConcurrent
+		}
+		mu.Unlock()
+
+		// Simulate work
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		currentConcurrent--
+		mu.Unlock()
+	}
+
+	// Run multiple tasks with limited parallelism
+	maxConcurrent = 0
+	currentConcurrent = 0
+
+	// This simulates what NewParallelExecutor does with a semaphore
+	var wg sync.WaitGroup
+	semaphore := make(chan struct{}, 2) // Limit to 2 concurrent
+
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}        // Acquire
+			defer func() { <-semaphore }() // Release
+			trackingFunc()
+		}()
+	}
+
+	wg.Wait()
+
+	// With a semaphore of 2, max concurrent should be <= 2
+	assert.LessOrEqual(t, maxConcurrent, 2, "Maximum concurrent executions should not exceed limit")
+	assert.GreaterOrEqual(t, maxConcurrent, 1, "Should have at least 1 concurrent execution")
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/joho/godotenv"
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/model"

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nektos/act/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type stepActionLocalMocks struct {

--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -109,17 +109,12 @@ func (sar *stepActionRemote) prepareActionExecutor() common.Executor {
 		}
 
 		actionDir := fmt.Sprintf("%s/%s", sar.RunContext.ActionCacheDir(), sar.Step.UsesHash())
+		token := getGitCloneToken(sar.getRunContext().Config, sar.remoteAction.CloneURL(sar.RunContext.Config.DefaultActionInstance))
 		gitClone := stepActionRemoteNewCloneExecutor(git.NewGitCloneExecutorInput{
-			URL:   sar.remoteAction.CloneURL(sar.RunContext.Config.DefaultActionInstance),
-			Ref:   sar.remoteAction.Ref,
-			Dir:   actionDir,
-			Token: "", /*
-				Shouldn't provide token when cloning actions,
-				the token comes from the instance which triggered the task,
-				however, it might be not the same instance which provides actions.
-				For GitHub, they are the same, always github.com.
-				But for Gitea, tasks triggered by a.com can clone actions from b.com.
-			*/
+			URL:         sar.remoteAction.CloneURL(sar.RunContext.Config.DefaultActionInstance),
+			Ref:         sar.remoteAction.Ref,
+			Dir:         actionDir,
+			Token:       token,
 			OfflineMode: sar.RunContext.Config.ActionOfflineMode,
 
 			InsecureSkipTLS: sar.cloneSkipTLS(), // For Gitea

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/common/git"

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 func TestMergeIntoMap(t *testing.T) {


### PR DESCRIPTION
Most of the PRs upstream are additive. The biggest risk is the upgrade of YAML from v3->v4. Seems like there are tests for an edge case that broke.
Local testing of generate-bom against this version worked just fine.