### PR TITLE
fix: reusable workflows should pull updated code

### DIFF
--- a/pkg/runner/reusable_workflow.go
+++ b/pkg/runner/reusable_workflow.go
@@ -3,11 +3,8 @@ package runner
 import (
 	"archive/tar"
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"net/url"
-	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -135,29 +132,20 @@ func newMutexExecutor(executor common.Executor) common.Executor {
 }
 
 func cloneIfRequired(rc *RunContext, remoteReusableWorkflow remoteReusableWorkflow, targetDirectory, token string) common.Executor {
-	return common.NewConditionalExecutor(
-		func(ctx context.Context) bool {
-			_, err := os.Stat(targetDirectory)
-			notExists := errors.Is(err, fs.ErrNotExist)
-			return notExists
-		},
-		func(ctx context.Context) error {
-			// interpolate the cloneURL
-			cloneURL := rc.NewExpressionEvaluator(ctx).Interpolate(ctx, remoteReusableWorkflow.CloneURL())
-			// Do not change the remoteReusableWorkflow.URL, because:
-			// 	1. Gitea doesn't support specifying GithubContext.ServerURL by the GITHUB_SERVER_URL env
-			//	2. Gitea has already full URL with rc.Config.GitHubInstance when calling newRemoteReusableWorkflowWithPlat
-			// remoteReusableWorkflow.URL = rc.getGithubContext(ctx).ServerURL
-			return git.NewGitCloneExecutor(git.NewGitCloneExecutorInput{
-				URL:         cloneURL,
-				Ref:         remoteReusableWorkflow.Ref,
-				Dir:         targetDirectory,
-				Token:       token,
-				OfflineMode: rc.Config.ActionOfflineMode,
-			})(ctx)
-		},
-		nil,
-	)
+	return func(ctx context.Context) error {
+		cloneURL := rc.NewExpressionEvaluator(ctx).Interpolate(ctx, remoteReusableWorkflow.CloneURL())
+		// Do not change the remoteReusableWorkflow.URL, because:
+		// 	1. Gitea doesn't support specifying GithubContext.ServerURL by the GITHUB_SERVER_URL env
+		//	2. Gitea has already full URL with rc.Config.GitHubInstance when calling newRemoteReusableWorkflowWithPlat
+		// remoteReusableWorkflow.URL = rc.getGithubContext(ctx).ServerURL
+		return git.NewGitCloneExecutor(git.NewGitCloneExecutorInput{
+			URL:         cloneURL,
+			Ref:         remoteReusableWorkflow.Ref,
+			Dir:         targetDirectory,
+			Token:       token,
+			OfflineMode: rc.Config.ActionOfflineMode,
+		})(ctx)
+	}
 }
 
 func newReusableWorkflowExecutor(rc *RunContext, directory string, workflow string) common.Executor {


### PR DESCRIPTION
There is a stale cache issue with reusable workflows. They are pulled once for a specific ref and never pulled again if they already exist in the cache. This differs from what happens with the `use` directive for steps, which always attempt to pull updated code for a given ref. This fix removes the conditional cache check to align reusable workflows with the logic used for reusable steps.